### PR TITLE
makes git user and group configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,11 @@
 default['ruby_build']['git_url'] = "git://github.com/sstephenson/ruby-build.git"
 default['ruby_build']['git_ref'] = "master"
 
+if platform == "ubuntu"
+  default['ruby_build']['git_user'] = 'ubuntu'
+  default['ruby_build']['git_group'] = 'ubuntu'
+end
+
 # default base path for a system-wide installed Ruby
 default['ruby_build']['default_ruby_base_path'] = "/usr/local/ruby"
 
@@ -58,3 +63,4 @@ when "mac_os_x"
   node.set['ruby_build']['install_pkgs_cruby'] = []
   node.set['ruby_build']['install_pkgs_jruby'] = []
 end
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,8 @@ end
 
 git_url = node['ruby_build']['git_url']
 git_ref = node['ruby_build']['git_ref']
+git_user = node['ruby_build']['git_user']
+git_group = node['ruby_build']['git_group']
 upgrade_strategy  = build_upgrade_strategy(node['ruby_build']['upgrade'])
 
 cache_path  = Chef::Config['file_cache_path']
@@ -52,6 +54,9 @@ end
 git src_path do
   repository  git_url
   reference   git_ref
+
+  user  git_user
+  group git_group
 
   if upgrade_strategy == "none"
     action    :checkout


### PR DESCRIPTION
re-cooking a ubuntu server with knife-solo was failing because the ruby-build checkout directory was owned by root
