### PR TITLE
Use the HTTPS clone URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 #
 
 # git repository containing the ruby-build framework
-default['ruby_build']['git_url'] = "git://github.com/sstephenson/ruby-build.git"
+default['ruby_build']['git_url'] = "https://github.com/sstephenson/ruby-build.git"
 default['ruby_build']['git_ref'] = "master"
 
 # default base path for a system-wide installed Ruby


### PR DESCRIPTION
HTTPS clone URLs are just as fast as `git://` (as of Git v1.6.6), and they work transparently through firewalls and proxies.
