### PR TITLE
make notify calls explicit

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,5 +59,5 @@ git src_path do
     action    :sync
   end
 
-  notifies :run, resources(:execute => "Install ruby-build"), "execute[Install ruby-build]", :immediately
+  notifies :run, resources(:execute => "Install ruby-build"), :immediately
 end


### PR DESCRIPTION
The version of Chef that AWS's OpsWorks employs does not handle the `notifies` calls with implicit resource shortcuts.  This issue is outlined [here](https://github.com/aws/opsworks-cookbooks/issues/28#issuecomment-17371664).

Accepting this pull request will not materially change the makeup of the cookbook and will ease the bleeding-edge users of AWS OpsWorks.  Ultimately, OpsWorks will upgrade Chef and this will be a non-issue.  But, until then, this pull request will help myself and others.
