### PR TITLE
Fix some CHEF-3694 warnings when using with rbenv

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,12 +31,15 @@ src_path    = "#{cache_path}/ruby-build"
 
 unless mac_with_no_homebrew
   Array(node['ruby_build']['install_pkgs']).each do |pkg|
-    package pkg
+    package "installing ruby_build dependency: #{pkg}" do
+      package_name pkg
+    end
   end
 
   Array(node['ruby_build']['install_git_pkgs']).each do |pkg|
-    package pkg do
+    package "installing ruby_build dependency: #{pkg}" do
       not_if "git --version >/dev/null"
+      package_name pkg
     end
   end
 end


### PR DESCRIPTION
[CHEF-3694](http://tickets.opscode.com/browse/CHEF-3694) warnings caused by package resource re-definition with same name as another cookbook.

I'd think that this is so common there would be a better way to avoid this warning...
