### PR TITLE
fix regexp when install ruby 2.1.0

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -74,7 +74,7 @@ end
 
 def install_ruby_dependencies
   case ::File.basename(new_resource.definition)
-  when /^\d\.\d\.\d-/, /^rbx-/, /^ree-/
+  when /^\d\.\d\.\d/, /^rbx-/, /^ree-/
     pkgs = node['ruby_build']['install_pkgs_cruby']
   when /^jruby-/
     pkgs = node['ruby_build']['install_pkgs_jruby']


### PR DESCRIPTION
since the version of 2.1.0 is without the '-pxxx'

``` shell
  ruby-build 2.1.0
```
