### PR TITLE
Fixed support for Amazon Linux in Chef 13.x

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['ruby_build']['default_ruby_base_path'] = '/usr/local/ruby'
 default['ruby_build']['upgrade'] = 'none'
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   default['ruby_build']['install_pkgs'] = %w( tar bash curl )
   default['ruby_build']['install_pkgs_cruby'] =
     %w( gcc-c++ patch readline-devel zlib-devel


### PR DESCRIPTION
### Description
Fixed support for Amazon Linux in Chef 13.
`platform_family` of Amazon Linux is judged as `amazon` in Chef 13, so installation fails because some attributes are insufficient.
I activate some attributes for Amazon Linux in `attributes/default.rb`.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/60)
<!-- Reviewable:end -->
