### PR TITLE
Silence deprecation warning CHEF-25

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,12 @@ driver:
 
 provisioner:
   name: chef_zero
-  deprecations_as_errors: true
+  client_rb:
+    treat_deprecation_warnings_as_errors: true
+    silence_deprecation_warnings:
+    # There's a deprecation warning in the homebrew cookbook right now
+    # Might be gone with Chef 14.5
+    - chef-25
 
 verifier:
   name: inspec


### PR DESCRIPTION
## Description

This doesn't "fix" the deprecation as much as it just silences it so we get green test runs again. According to @tas50 these should be gone in Chef 14.5, and it seems the deprecation isn't in this cookbook itself but in homebrew if I understood correctly.

https://travis-ci.org/sous-chefs/ruby_build/jobs/421278913#L556-L572

### Issues Resolved

Builds should be green again.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/67)
<!-- Reviewable:end -->
