### PR TITLE
ignore CHEF-25 as there is not much we can do without breaking users

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -9,6 +9,10 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  client_rb:
+    silence_deprecation_warnings:
+      # there is not much we can do to appease this short of breaking 99% of users/consumers
+      - chef-25
 
 verifier:
   name: inspec


### PR DESCRIPTION
Eventually we will want to do that but this is not the time.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Description

Silence deprecation warning until we are ready to break compatibility

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/68)
<!-- Reviewable:end -->
