### PR TITLE
Remove automake-wrapper dependency package for FreeBSD

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,7 +72,7 @@ when 'mac_os_x'
 when 'freebsd'
   default['ruby_build']['install_pkgs'] = []
   default['ruby_build']['install_pkgs_cruby'] =
-    %w( autoconf autoconf-wrapper automake automake-wrapper indexinfo
+    %w( autoconf autoconf-wrapper automake indexinfo
         libedit libffi libyaml m4 perl5 gmake )
   default['ruby_build']['install_pkgs_jruby'] =
     %w( alsa-lib bash dejavu expat fixesproto fontconfig freetype2


### PR DESCRIPTION
## Description

Package `automake-wrapper` has been removed from FreeBSD packages and it cannot be installed:
https://www.freebsd.org/cgi/ports.cgi?query=automake&stype=name

Now ruby builds without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/70)
<!-- Reviewable:end -->
