### PR TITLE
README: update build status badge to use circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # ruby-build Chef Cookbook
 
-[![Build Status](https://travis-ci.org/sous-chefs/ruby_build.svg?branch=master)](https://travis-ci.org/sous-chefs/ruby_build)
 [![Cookbook Version](https://img.shields.io/cookbook/v/ruby_build.svg)](https://supermarket.chef.io/cookbooks/ruby_build)
-
+[![Build Status](https://img.shields.io/circleci/project/github/sous-chefs/ruby_build/master.svg)](https://circleci.com/gh/sous-chefs/ruby_build)
 
 ## Description
 


### PR DESCRIPTION
Yes, it's failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/81)
<!-- Reviewable:end -->
