### PR TITLE
Fix libgdbm package name for debian 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ workflows:
           suite: default-debian-9
           requires: *lint_and_unit
       - kitchen/dokken-single:
+          name: default-debian-10
+          suite: default-debian-10
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
           name: default-centos-6
           suite: default-centos-6
           requires: *lint_and_unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the ruby_build cookboo
 - Fix YAML
 - Use platform? helper in the attributes file
 - Remove the unnecessary long_description field in metadata.rb
+- Fix libgdbm package name in attributes for debian 10
 
 ## 1.2.0 (2019-23-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the ruby_build cookboo
 - Use platform? helper in the attributes file
 - Remove the unnecessary long_description field in metadata.rb
 - Fix libgdbm package name in attributes for debian 10
+- Add debian-10 platform to test kitchen configurations
 
 ## 1.2.0 (2019-23-01)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,7 +52,7 @@ when 'debian'
     elsif node['platform_version'].to_i >= 10
       %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
           zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev
-          libc6-dev libffi-dev libgdbm5 libgdbm-dev )
+          libc6-dev libffi-dev libgdbm6 libgdbm-dev )
     else
       %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
           zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,10 @@ when 'debian'
       %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
           zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev
           libc6-dev libffi-dev libgdbm3 libgdbm-dev )
+    elsif platform?('ubuntu') && node['platform_version'].to_i >= 10
+      %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
+          zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev
+          libc6-dev libffi-dev libgdbm5 libgdbm-dev )
     elsif node['platform_version'].to_i >= 10
       %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
           zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,6 +22,14 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
 
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install sudo -y
+
   - name: centos-6
     driver:
       image: dokken/centos-6

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,6 +15,7 @@ platforms:
   - name: centos-6
   - name: centos-7
   - name: debian-9
+  - name: debian-10
   - name: ubuntu-16.04
   - name: ubuntu-18.04
 

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -5,7 +5,7 @@
 
 default['java']['jdk_version'] = if platform_family?('debian') && node['platform_version'].to_f < 9
                                    '7'
-                                 elsif platform_family?('debian') && node['platform_version'].to_f >= 10
+                                 elsif platform?('debian') && node['platform_version'].to_f >= 10
                                    '11'
                                  else
                                    '8'

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -5,6 +5,8 @@
 
 default['java']['jdk_version'] = if platform_family?('debian') && node['platform_version'].to_f < 9
                                    '7'
+                                 elsif platform_family?('debian') && node['platform_version'].to_f >= 10
+                                   '11'
                                  else
                                    '8'
                                  end


### PR DESCRIPTION
# Description

This PR changes the package name for libgdbm used in debian 10.

## Issues Resolved

#97 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/98)
<!-- Reviewable:end -->
