### PR TITLE
Update libgdbm6 for Ubuntu 19.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           - 'centos-7'
           - 'ubuntu-1604'
           - 'ubuntu-1804'
+          - 'ubuntu-1910'
         suite:
           - 'default'
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the ruby_build cookboo
 - Use platform? helper in the attributes file
 - Remove the unnecessary long_description field in metadata.rb
 - Fix libgdbm package name in attributes for debian 10
+- Fix libgdbm package name in attributes for Ubuntu 19
 - Add debian-10 platform to test kitchen configurations
 - Migrate to github actions
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -18,7 +18,7 @@ def code_changes?
 end
 
 def test_changes?
-  tests = %w(spec test .kitchen.yml .kitchen.dokken.yml)
+  tests = %w(spec test kitchen.yml kitchen.dokken.yml)
   tests.each do |location|
     return true unless git.modified_files.grep(/#{location}/).empty?
   end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,11 @@ when 'rhel', 'fedora', 'amazon'
 when 'debian'
   default['ruby_build']['install_pkgs'] = %w( tar bash curl )
   default['ruby_build']['install_pkgs_cruby'] =
-    if platform?('ubuntu') && node['platform_version'] == '16.04'
+    if platform?('ubuntu') && node['platform_version'].to_i >= 19
+      %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
+          zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev
+          libc6-dev libffi-dev libgdbm6 libgdbm-dev )
+    elsif platform?('ubuntu') && node['platform_version'] == '16.04'
       %w( autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev
           zlib1g-dev libsqlite3-dev libxml2-dev libxslt1-dev
           libc6-dev libffi-dev libgdbm3 libgdbm-dev )

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -59,3 +59,11 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
+
+  - name: ubuntu-19.10
+    driver:
+      image: dokken/ubuntu-19.10
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install sudo -y


### PR DESCRIPTION
# Description

Updates to libgdbm6, which [ships with](https://packages.ubuntu.com/search?keywords=libgdbm) Ubuntu 19.04 (disco) and 19.10 (eoan).

#### Testing

I would've added both 19.04 and 19.10 to the test matrix but looks like Ubuntu's [only providing 19.10 on Dockerhub](https://hub.docker.com/_/ubuntu). I have not tested 19.04 manually.

I also expect a similar problem to exist on Ubuntu 18.04 (bionic) and 18.10 (cosmic), which look like they require libgdbm5, but I haven't fixed that here.

#### Bonus tooling fix

Looks like the Danger check for added tests was looking at the wrong kitchen*.yml files and raising an error even if a new test was added to the matrix.

## Issues Resolved

[Issue #102](https://github.com/sous-chefs/ruby_build/issues/102)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.