### PR TITLE
Support Chef temp directory being mounted noexec and installation path being pre-created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- support Chef temporary directory being located on a volume mounted `noeexec`
+- support Chef temporary directory being located on a volume mounted `noexec`
 - support Ruby installation directory being created ahead of time
 
 ## 2.1.3 - *2021-06-01*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- support Chef temporary directory being located on a volume mounted `noeexec`
+- support Ruby installation directory being created ahead of time
+
 ## 2.1.3 - *2021-06-01*
 
 ## 2.1.2 - *2020-12-02*

--- a/resources/definition.rb
+++ b/resources/definition.rb
@@ -81,7 +81,7 @@ action :install do
     environment env
     user new_resource.user
     group new_resource.group
-    not_if { ::File.exist?(installation_path) }
+    not_if { ::File.exist?("#{installation_path}/bin") }
     live_stream true
     action :run
   end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -25,7 +25,7 @@ action :install do
 
   execute 'Install ruby-build' do
     cwd src_path
-    command %(./install.sh)
+    command %(sh ./install.sh)
     not_if { ::File.exist?('/usr/local/bin/ruby-build') }
   end
 end


### PR DESCRIPTION
# Description

On my system, I have `/var/tmp` mounted noexec, so the Chef temp directory can't directly execute the install.sh shell script. I also create my Ruby installation location as a separate ZFS dataset (with nosuid and nodev). This PR updates the installer to call the script with `sh`, which works under `noexec` and to check for `.../bin` being created to see if it needs to install Ruby or not (rather than checking if the destination exists at all).

## Issues Resolved

N/A

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
