### PR TITLE
Retry when cloning the ruby-build repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Retry when cloning the ruby-build code repository
+
 ## 2.1.4 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management
-- Retry when cloning the ruby-build code repository
 
 ## 2.1.3 - *2021-06-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.1.4 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management
+- Retry when cloning the ruby-build code repository
 
 ## 2.1.3 - *2021-06-01*
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -21,6 +21,8 @@ action :install do
   git src_path do
     repository 'https://github.com/rbenv/ruby-build.git'
     revision new_resource.git_ref unless new_resource.git_ref == 'master'
+    retries 5
+    retry_delay 5
   end
 
   execute 'Install ruby-build' do


### PR DESCRIPTION
# Description

This pull request adds retries to the resource that attempts to clone the ruby-build Github repository. Github has recently shown an increase in intermittent API failures, one of which is happening when creating this PR in the EU. 
This is not new functionality; therefore, no tests are added. 

## Issues Resolved

n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
