### PR TITLE
Add verbose option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,34 +7,11 @@ name: ci
     branches: [master]
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: 'lint-unit'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Add `verbose` option
+- Remove Delivery and move to calling RSpec directly via a reusable workflow
 
 ## 2.2.3 - *2022-05-16*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `verbose` option
+
 ## 2.2.3 - *2022-05-16*
 
 Standardise files with files in sous-chefs/repo-management

--- a/documentation/resources/definition.md
+++ b/documentation/resources/definition.md
@@ -7,10 +7,11 @@ Install a Ruby Definition (Ruby version)
 | Property      | Ruby Type | Default           | Description                                           |
 | ------------- | --------- | ----------------- | ----------------------------------------------------- |
 | `definition`  | String    |                   | Version of Ruby to install                            |
-| `prefix_path` | String    | `/usr/local/ruby` | Location to install Ruby                              |
 | `environment` | String    |                   | Environment to pass to the ruby-build install process |
-| `user`        | String    |                   | User to install as                                    |
 | `group`       | String    |                   | Group to install as                                   |
+| `prefix_path` | String    | `/usr/local/ruby` | Location to install Ruby                              |
+| `user`        | String    |                   | User to install as                                    |
+| `verbose`     | Boolean   | `false`           | Print compilation status to stdout                    |
 
 ## Example Usage
 

--- a/resources/definition.rb
+++ b/resources/definition.rb
@@ -13,6 +13,10 @@ property :prefix_path, String,
   default: '/usr/local/ruby',
   description: 'Location to install Ruby'
 
+property :verbose, [true, false],
+  default: false,
+  description: 'print compilation status to stdout'
+
 # NOTE: adding the Ruby version to the installation prefix
 # by default is unexpected and will likely lead to user
 # problems. Now defaults to false.
@@ -66,6 +70,8 @@ action :install do
     new_resource.definition,
     installation_path,
   ].join(' ')
+
+  ruby_build_cmd += ' --verbose' if new_resource.verbose
 
   if new_resource.patch
     patch_path = "#{Chef::Config[:file_cache_path]}/#{new_resource.patch}"


### PR DESCRIPTION
# Description

This is a simple change that allows users to set `verbose true` to get `--verbose` passed to `ruby_build` so that they can inspect compiler output or whatever.

## Issues Resolved

No existing issues. I needed to figure out why my build is failing on aarch64 :).

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.