### PR TITLE
Update yum config for CentOS Stream 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- CentOS Stream 9 uses 'crb' instead of the 'powertools' repo.
+
 ## 2.5.5 - *2023-10-26*
 
 ## 2.5.4 - *2023-09-29*

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -10,7 +10,13 @@ action :install do
   src_path = "#{Chef::Config['file_cache_path']}/ruby-build"
 
   if platform_family?('rhel')
-    if node['platform_version'].to_i >= 8
+    if node['platform_version'].to_i == 9
+      package 'yum-utils'
+
+      execute 'yum-config-manager --enable crb' do
+        not_if 'yum-config-manager --dump crb | grep -q "enabled = 1"'
+      end
+    elsif node['platform_version'].to_i == 8
       package 'yum-utils'
 
       execute 'yum-config-manager --enable powertools' do


### PR DESCRIPTION


# Description

The Powertools repo doesn't exist for CentOS Stream 9.  The equivalent packages are in the CRB repo.  This adds a second conditional statement to enable the CRB repo if the platform_version is `9` and changes the conditional for the powertools repo from `>= 8` to `== 8`

When trying to use this cookbook on CentOS Stream 9 is resulted in an error like below:

```
         * ruby_build_install[] action install
           * dnf_package[yum-utils] action install (up to date)
           * execute[yum-config-manager --enable powertools] action run

             ================================================================================
             Error executing action `run` on resource 'execute[yum-config-manager --enable powertools]'
             ================================================================================

             Mixlib::ShellOut::ShellCommandFailed
             ------------------------------------
             Expected process to exit with [0], but received '1'
             ---- Begin output of yum-config-manager --enable powertools ----
             STDOUT:
             STDERR: Error: No matching repo to modify: powertools.
             ---- End output of yum-config-manager --enable powertools ----
             Ran yum-config-manager --enable powertools returned 1

             Cookbook Trace: (most recent call first)
             ----------------------------------------
             /tmp/kitchen/cache/cookbooks/ruby_build/resources/install.rb:16:in `block in class_from_file'

             Resource Declaration:
             ---------------------
             # In /tmp/kitchen/cache/cookbooks/ruby_build/resources/install.rb

       16:       execute 'yum-config-manager --enable powertools' do
       17:         not_if 'yum-config-manager --dump powertools | grep -q "enabled = 1"'
       18:       end
       19:     end
```

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
