### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,9 @@ jobs:
       matrix:
         os:
           - "almalinux-8"
-          - "almalinux-9"
-          - "almalinux-10"
-          - "amazonlinux-2023"
-          - "centos-stream-9"
-          - "centos-stream-10"
-          - "debian-12"
-          - "debian-13"
-          - "fedora-latest"
-          - "opensuse-leap-15"
-          - "oraclelinux-8"
-          - "oraclelinux-9"
           - "rockylinux-8"
-          - "rockylinux-9"
-          - "rockylinux-10"
           - "ubuntu-2004"
           - "ubuntu-2204"
-          - "ubuntu-2404"
         suite:
           - "default"
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,23 @@ jobs:
       matrix:
         os:
           - "almalinux-8"
-          - "centos-7"
-          - "centos-stream-8"
-          - "debian-10"
-          - "debian-11"
+          - "almalinux-9"
+          - "almalinux-10"
+          - "amazonlinux-2023"
+          - "centos-stream-9"
+          - "centos-stream-10"
+          - "debian-12"
+          - "debian-13"
+          - "fedora-latest"
+          - "opensuse-leap-15"
+          - "oraclelinux-8"
+          - "oraclelinux-9"
           - "rockylinux-8"
-          - "ubuntu-1804"
+          - "rockylinux-9"
+          - "rockylinux-10"
           - "ubuntu-2004"
           - "ubuntu-2204"
+          - "ubuntu-2404"
         suite:
           - "default"
       fail-fast: false
@@ -39,7 +48,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
       - name: Dokken
         uses: actionshub/test-kitchen@main
         env:
@@ -56,7 +65,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
       - name: Kitchen Test
         uses: actionshub/test-kitchen@main
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,5 @@ AllCops:
   Exclude:
     - 'Dangerfile'
     - 'resources/homebrew_update.rb'
+    - 'vendor/**/*'
     # This will be moved into Chef Infra Core so I want to preserve the quotes

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "3f6451ca3509ae9f5a9e7bb9cff16932b351d2aacd100cab2bfe17c274d03712",
+  "revision_id": "6acbaa01bc76e4e522f3971c561c32a551273ea043e58f425c907f0bf41eeec1",
   "name": "ruby_build",
   "run_list": [
     "recipe[test::default]"
@@ -27,14 +27,14 @@
     },
     "ruby_build": {
       "version": "2.5.12",
-      "identifier": "06ed00751d9164e8c3c1fcdca5724685fd294825",
-      "dotted_decimal_identifier": "1949436080918884.65517432535295346.77541291935781",
+      "identifier": "4d69fe0305af8d17f1deb92aa104860274568a83",
+      "dotted_decimal_identifier": "21790112900034445.6739863355957508.147345099885187",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/ruby_build.git",
-        "revision": "3f076609f1766a27193c5edf4d93ec1a4320ca61",
+        "revision": "07335944f462e81987610455906fc2f2591ea67c",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -47,14 +47,14 @@
     },
     "test": {
       "version": "1.0.0",
-      "identifier": "8d6d7c70e209ff1d701c07390ca34eb4096d656c",
-      "dotted_decimal_identifier": "39808352953436671.8286040007183523.86535159244140",
+      "identifier": "5e812c6fbd7fd07e16cfe87849d7bf64cf448377",
+      "dotted_decimal_identifier": "26600675664035792.35490929279781335.210439695008631",
       "source": "test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/ruby_build.git",
-        "revision": "3f076609f1766a27193c5edf4d93ec1a4320ca61",
+        "revision": "07335944f462e81987610455906fc2f2591ea67c",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,131 @@
+{
+  "revision_id": "3f6451ca3509ae9f5a9e7bb9cff16932b351d2aacd100cab2bfe17c274d03712",
+  "name": "ruby_build",
+  "run_list": [
+    "recipe[test::default]"
+  ],
+  "named_run_lists": {
+    "default": [
+      "recipe[test::default]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "homebrew": {
+      "version": "7.0.0",
+      "identifier": "456d1e381e87f21073968b4477cfdf06a4c42c57",
+      "dotted_decimal_identifier": "19541749951006706.4630690046179279.245219627117655",
+      "cache_key": "homebrew-f4a84d4e2e8bc6f17d7d4c5c439be4d29fbc34db",
+      "origin": "https://github.com/sous-chefs/homebrew.git",
+      "source_options": {
+        "git": "https://github.com/sous-chefs/homebrew.git",
+        "revision": "f4a84d4e2e8bc6f17d7d4c5c439be4d29fbc34db",
+        "branch": "main"
+      }
+    },
+    "ruby_build": {
+      "version": "2.5.12",
+      "identifier": "06ed00751d9164e8c3c1fcdca5724685fd294825",
+      "dotted_decimal_identifier": "1949436080918884.65517432535295346.77541291935781",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "https://github.com/sous-chefs/ruby_build.git",
+        "revision": "3f076609f1766a27193c5edf4d93ec1a4320ca61",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/chore/migrate-to-policyfile"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "test": {
+      "version": "1.0.0",
+      "identifier": "8d6d7c70e209ff1d701c07390ca34eb4096d656c",
+      "dotted_decimal_identifier": "39808352953436671.8286040007183523.86535159244140",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "https://github.com/sous-chefs/ruby_build.git",
+        "revision": "3f076609f1766a27193c5edf4d93ec1a4320ca61",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/chore/migrate-to-policyfile"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    },
+    "yum-epel": {
+      "version": "5.0.10",
+      "identifier": "3ffd59317825177023566a99bf5940e29163cfd4",
+      "dotted_decimal_identifier": "18011483056645399.31564051454213977.71341846024148",
+      "cache_key": "yum-epel-0ae39de8b609c2904012f4da4cf261b6e3361f74",
+      "origin": "https://github.com/sous-chefs/yum-epel.git",
+      "source_options": {
+        "git": "https://github.com/sous-chefs/yum-epel.git",
+        "revision": "0ae39de8b609c2904012f4da4cf261b6e3361f74",
+        "branch": "main"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "homebrew",
+        ">= 0.0.0"
+      ],
+      [
+        "ruby_build",
+        ">= 0.0.0"
+      ],
+      [
+        "test",
+        ">= 0.0.0"
+      ],
+      [
+        "yum-epel",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "homebrew (7.0.0)": [
+
+      ],
+      "ruby_build (2.5.12)": [
+        [
+          "yum-epel",
+          ">= 0.0.0"
+        ],
+        [
+          "homebrew",
+          ">= 0.0.0"
+        ]
+      ],
+      "test (1.0.0)": [
+        [
+          "ruby_build",
+          ">= 0.0.0"
+        ]
+      ],
+      "yum-epel (5.0.10)": [
+
+      ]
+    }
+  }
+}

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,12 +2,12 @@
 
 name 'ruby_build'
 
-default_source :supermarket
-
 run_list 'test::default'
 
 cookbook 'ruby_build', path: '.'
 cookbook 'test', path: 'test/cookbooks/test'
+cookbook 'homebrew', git: 'https://github.com/sous-chefs/homebrew.git', branch: 'main'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
 
 Dir.entries('./test/cookbooks/test/recipes').select { |f| f.end_with?('.rb') }.each do |test|
   test = test.delete_suffix('.rb')

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'ruby_build'
+
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'ruby_build', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'
+
+Dir.entries('./test/cookbooks/test/recipes').select { |f| f.end_with?('.rb') }.each do |test|
+  test = test.delete_suffix('.rb')
+  named_run_list :"#{test}", "test::#{test}"
+end

--- a/kitchen.macos.yml
+++ b/kitchen.macos.yml
@@ -7,7 +7,7 @@ provisioner:
   require_chef_omnibus: false
   name: chef_zero
   install_strategy: skip
-  chef_client_path: "/opt/chef-workstation/bin/chef-client"
+  chef_client_path: "/usr/local/bin/cinc-client"
   deprecations_as_errors: false
   sudo: true
 

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -2,7 +2,7 @@ class Chef
   module Rbenv
     module MacOs
       def openssl_prefix
-        `/usr/local/bin/brew --prefix openssl@3`.strip!
+        `brew --prefix openssl@3`.strip!
       end
     end
 

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -2,7 +2,7 @@ class Chef
   module Rbenv
     module MacOs
       def openssl_prefix
-        `/usr/local/bin/brew --prefix openssl@1.1`.strip!
+        `/usr/local/bin/brew --prefix openssl@3`.strip!
       end
     end
 
@@ -31,7 +31,7 @@ class Chef
         when 'suse'
           %w( gcc make automake gdbm-devel libyaml-devel ncurses-devel readline-devel zlib-devel libopenssl-devel patch )
         when 'mac_os_x'
-          %w( openssl@1.1 readline )
+          %w( openssl@3 readline )
         end
       end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -24,7 +24,7 @@ action :install do
       end
     end
 
-    include_recipe 'yum-epel'
+    yum_epel 'default'
   end
 
   package %w(tar bash curl git) unless platform_family?('mac_os_x', 'freebsd')

--- a/spec/resources/install_spec.rb
+++ b/spec/resources/install_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'test::default' do
+  context 'AlmaLinux 8' do
+    platform 'almalinux', '8'
+    step_into :ruby_build_install
+
+    before do
+      stub_command('yum-config-manager --dump powertools | grep -q "enabled = 1"').and_return(false)
+    end
+
+    it { is_expected.to install_package('yum-utils') }
+    it { is_expected.to run_execute('yum-config-manager --enable powertools') }
+    it { is_expected.to create_yum_epel('default') }
+    it { is_expected.not_to include_recipe('yum-epel') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require_relative '../libraries/package_deps'
 
 RSpec.configure do |config|

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -3,7 +3,9 @@ homebrew_update
 
 ruby_build_install
 
-ruby_build_definition '3.0.4' do
+ruby_version = platform_family?('mac_os_x') ? '3.3.10' : '3.0.4'
+
+ruby_build_definition ruby_version do
   version_prefix true
-  patch 'test.patch'
+  patch 'test.patch' unless platform_family?('mac_os_x')
 end

--- a/test/integration/default/controls/verify_ruby_build.rb
+++ b/test/integration/default/controls/verify_ruby_build.rb
@@ -1,10 +1,13 @@
+ruby_version = os.darwin? ? '3.3.10' : '3.0.4'
+ruby_api_version = ruby_version.sub(/\.\d+$/, '.0')
+
 control 'Check definitions' do
   impact 1.0
   title 'Verify we can return a list of definitions'
   desc 'Verify we can get a list of Ruby definitions'
   describe command('/usr/local/bin/ruby-build --definitions') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match /3.0.4/ }
+    its('stdout') { should match /#{Regexp.escape(ruby_version)}/ }
   end
 end
 
@@ -19,9 +22,9 @@ control 'ruby-build binary should work' do
 end
 
 gem_cmd = if os.darwin?
-            'sudo /usr/local/ruby/3.0.4/bin/gem install ffi --no-document'
+            "sudo /usr/local/ruby/#{ruby_version}/bin/gem install ffi --no-document"
           else
-            '/usr/local/ruby/3.0.4/bin/gem install ffi --no-document'
+            "/usr/local/ruby/#{ruby_version}/bin/gem install ffi --no-document"
           end
 
 control 'Install a Ruby gem' do
@@ -34,8 +37,8 @@ control 'Install a Ruby gem' do
     its('stdout') { should match /Successfully installed ffi/ }
   end
 
-  describe command('/usr/local/ruby/3.0.4/bin/gem env') do
+  describe command("/usr/local/ruby/#{ruby_version}/bin/gem env") do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match %r{gems/3.0.0} }
+    its('stdout') { should match %r{gems/#{Regexp.escape(ruby_api_version)}} }
   end
 end


### PR DESCRIPTION
## Summary
- replace Berksfile with Policyfile.rb
- switch ChefSpec to Policyfile support
- update Copilot setup to run chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_build/195)
<!-- Reviewable:end -->
